### PR TITLE
[#4] Check distance between Player & Enemy before starting

### DIFF
--- a/src/classes/Actor.cpp
+++ b/src/classes/Actor.cpp
@@ -1,8 +1,7 @@
+#include <stdio.h>
+#include <cmath>
 
 #include "Actor.h"
-
-
-#include <cmath>
 
 /*
  * Comparison
@@ -17,12 +16,18 @@ bool Actor::isAdjacent(vec2i const targetPos) {
     return (getDistanceX(targetPos) <= 1 && getDistanceY(targetPos) <= 1);
 };
 
+int_fast8_t Actor::getDistance(vec2i const targetPos) {
+    return sqrt(
+        std::pow(getDistanceY(targetPos), 2) + std::pow(getDistanceX(targetPos), 2)
+    );
+};
+
 int_fast8_t Actor::getDistanceX(vec2i const targetPos) {
-    return std::abs(getPos().y - targetPos.y);
+    return std::abs(getPos().x - targetPos.x);
 };
 
 int_fast8_t Actor::getDistanceY(vec2i const targetPos) {
-    return std::abs(getPos().x - targetPos.x);
+    return std::abs(getPos().y - targetPos.y);
 };
 
 /*

--- a/src/classes/Actor.h
+++ b/src/classes/Actor.h
@@ -9,6 +9,7 @@ class Actor {
 
         bool atop(vec2i const targetPos);
         bool isAdjacent(vec2i const targetPos);
+        int_fast8_t getDistance(vec2i const targetPos);
         int_fast8_t getDistanceX(vec2i const targetPos);
         int_fast8_t getDistanceY(vec2i const targetPos);
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -28,6 +28,17 @@ int startGame() {
     box(wgame, 0, 0);
     keypad(wgame, true);
 
+    /*
+     * Check if Player & Enemy are too near each other.
+     * `42' here is the maximum allowable value, given
+     * that Player may spawn in the middle (39, 19) of
+     * the game_area.
+     */
+    while (player.getDistance(enemy.getPos()) <= 42) {
+        // Reroll ctor for new random start
+        enemy = Enemy();
+    }
+
     // Init placement of Player, Enemy, and Coins
     wmove(wgame, player.getPos().y, player.getPos().x);
     waddch(wgame, player.getDispChar());
@@ -118,6 +129,8 @@ int startGame() {
             + '{'
             + std::to_string(enemy.getPos().x) + ','
             + std::to_string(enemy.getPos().y) + '}'
+            + " dist: "
+            + std::to_string(player.getDistance(enemy.getPos()))
             + " steps: "
             + std::to_string(player.getSteps())
             + " ticks: "


### PR DESCRIPTION
And reroll Enemy's random start position until a favourable distance
presents itself.
- Add getDistance functions (returns hypotenuse of two Actors'
  coordinates).
- Fix bug where getDistance{X,Y} were returning to opposite values!
- Add distance (as `dist: n' to info panel crawl).
