### PR TITLE
Fix Enemy scare of Player bug

### DIFF
--- a/src/entities/Actor.h
+++ b/src/entities/Actor.h
@@ -12,11 +12,11 @@
 #include "Entity.h"
 
 struct Attributes {
-    uint_fast16_t ATK = 0;
-    uint_fast16_t ACT = 1;
-    uint_fast16_t LCK = 1;
-    uint_fast16_t HP = 100;
-    uint_fast16_t DF = 0;
+    uint_fast8_t ATK = 0;
+    uint_fast8_t ACT = 1;
+    uint_fast8_t LCK = 1;
+    uint_fast8_t HP = 100;
+    uint_fast8_t DF = 0;
 };
 
 class Actor : public Entity {
@@ -45,11 +45,11 @@ class Actor : public Entity {
         int   getSteps() { return steps; }
         int   getTicks() { return ticks; }
 
-        uint_fast16_t getATK() { return attr.ATK; }
-        uint_fast16_t getACT() { return attr.ACT; }
-        uint_fast16_t getLCK() { return attr.LCK; }
-        uint_fast16_t getHP() { return attr.HP; }
-        uint_fast16_t getDF() { return attr.DF; }
+        uint_fast8_t getATK() { return attr.ATK; }
+        uint_fast8_t getACT() { return attr.ACT; }
+        uint_fast8_t getLCK() { return attr.LCK; }
+        uint_fast8_t getHP() { return attr.HP; }
+        uint_fast8_t getDF() { return attr.DF; }
 
     protected:
         int   steps = 0;

--- a/src/entities/Enemy.cpp
+++ b/src/entities/Enemy.cpp
@@ -45,12 +45,14 @@ void Enemy::move() {
 
     int pool     = (100 - g->getDifficulty());
     int roll     = (rand() % pool);
-    bool chance  = (roll < modifier);
+    bool lucky  = (roll < modifier);
 
-    // Check if target is within aggro range
-    if (getDistance(target->getPos()) <= aggro) {
+    // Check if target is within range
+    if (getDistance(target->getPos()) <= 1) {
+        setPos(target->getPos());
+    } else if (getDistance(target->getPos()) <= aggro) {
         // If target unlucky, seek
-        if (chance) seek();
+        if (lucky) seek();
     } else {
         mill();
     }


### PR DESCRIPTION
Fixed by simply moving to Enemy to target's position if within 1 cell.
- While here:
  - Derez Attribute member by half (don't need all those bits).
  - Rename boolean `chance' to`lucky' - more semantic.
