### PR TITLE
[#70] Escape key exits game

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -145,6 +145,8 @@ int startGame() {
             case KEY_ENTER: /* numpad enter */
             case '\n':      /* keyboard return */
                 break;
+            case 27:        /* ESC */
+                isGameover = true;
             default:
                 player.wait();
                 infoMsg = player.getName();


### PR DESCRIPTION
Closes #70.

Pressing the escape key now exits the game.

This is done by simply piggy-backing onto the `isGameover` flag.
