### PR TITLE
[#19] Add & Implement Actor (player) statusbar

### DIFF
--- a/src/entities/Actor.cpp
+++ b/src/entities/Actor.cpp
@@ -11,8 +11,8 @@ Actor::Actor() {
 
 // TODO implement chance to block
 int_fast8_t Actor::defend(uint_fast8_t dmg) {
-    int_fast8_t effectiveDMG = std::abs((getDEF()) + dmg);
-    attr.HP -= effectiveDMG;
+    int_fast8_t effectiveDMG = std::abs((getDEF()) - dmg);
+    drainHP(effectiveDMG);
 
     if (attr.HP <= 0) {
         return -1;
@@ -114,6 +114,9 @@ void Actor::wait() {
     } else if (getST() < 100) {
         attr.ST += 5;
     }
+
+    messages[++lastMessage] = getType() + " " + getName() + " rests...";
+
     tick();
 }
 
@@ -126,6 +129,9 @@ void Actor::wait() {
 bool Actor::move() {
     tick();
     if (getST() > 0) step();
+
+
+    messages[++lastMessage] = "";
 
     return (getST() > 0);
 }

--- a/src/entities/Actor.h
+++ b/src/entities/Actor.h
@@ -3,21 +3,23 @@
 #define ACTOR_H
 
 #include <vector>
-#include <cstdlib>
-#include <ncurses.h>
 
 #include "../directions.h"
 #include "../game.h"
 #include "../windows/Window.h"
 #include "Entity.h"
 
+// XXX perhaps these should to floats
 struct Attributes {
     uint_fast8_t ATK = 1;
     uint_fast8_t DEF = 0;
     uint_fast8_t ACT = 1;
     uint_fast8_t LCK = 1;
     int_fast8_t HP = 100;
-    int_fast8_t ST = 100;  // Attacking/Defending uses stamina, which is required to move
+    int_fast8_t ST = 100;
+
+    int_fast8_t maxHP = 100;
+    int_fast8_t maxST = 100;
 };
 
 class Actor : public Entity {
@@ -52,6 +54,8 @@ class Actor : public Entity {
         uint_fast8_t getLCK() { return attr.LCK; }
         int_fast16_t getHP() { return attr.HP; }
         int_fast16_t getST() { return attr.ST; }
+        int_fast16_t getMaxHP() { return attr.maxHP; }
+        int_fast16_t getMaxST() { return attr.maxST; }
         std::string getLastMessage() { return messages[lastMessage]; }
         std::string getNewMessages();  // TODO return only un-previously-returned messages
 

--- a/src/entities/Player.cpp
+++ b/src/entities/Player.cpp
@@ -13,7 +13,9 @@ Player::Player() : Actor() {
     setType("Player");
     setName("Noop");
 
-    attr.LCK = (rand() % 3);  // Player luck 0 to 3
+    // Init Luck and Defense 0 to 3
+    attr.LCK = (rand() % 3);
+    attr.DEF = (rand() % 3);
 
     setPosRand();
 }

--- a/src/windows/StatusBar.cpp
+++ b/src/windows/StatusBar.cpp
@@ -1,0 +1,16 @@
+
+#include <string>
+
+#include "../game.h"
+#include "StatusBar.h"
+
+void StatusBar::refresh() {
+    Window::update();
+    write({1,0}, actor.getName());
+    write({1,1}, " HP: " + std::to_string(actor.getHP())
+            + "/" + std::to_string(actor.getMaxHP()) + " "
+            + "ST: " + std::to_string(actor.getST())
+            + "/" + std::to_string(actor.getMaxST()));
+    Window::refresh();
+}
+

--- a/src/windows/StatusBar.h
+++ b/src/windows/StatusBar.h
@@ -1,0 +1,21 @@
+#ifndef STATUSBAR_H
+#define STATUSBAR_H
+
+#include <string>
+#include "Window.h"
+#include "../entities/Actor.h"
+#include "../game.h"
+
+class StatusBar : public Window {
+    public:
+        // ctor - implicitly init Window, Actor
+        StatusBar(rect dim, Actor &a) : Window(dim), actor(a){}
+
+        void refresh();
+
+    private:
+        Actor &actor;
+};
+
+#endif
+


### PR DESCRIPTION
Closes #19, although more visual improvement could be made later.
- Adds Window-derived class `StatusBar`, which displays a given
  actor's Health & Stamina, as well as their name.
- Fix bug where diagnostic window and statusbar were not being
  drawn on first starting a game.
- Fix bug where a dead player could run around as long as there
  was no enemy around to "finish" them off.
- While here:
  - Use drainHP method to decrement actors' Health, rather than
    reaching into private members directly.
  - Add message to indicate actor is resting (waiting).
  - Add note to investigate float values for actor attributes.
  - Init Player defence between 0 & 3, rather than always 0.
  - Add some helpful comments to game.cpp.
  - Remove pointless diagnostic window spam (relevant bits are
    moved to our new statusbar).
