### PR TITLE
[#89] Convert to Game-Engine Library for External Use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 cmake_minimum_required(VERSION 2.8.12)
-project (termq)
+project (termq_lib)
 enable_language(CXX)
 
 include(CheckCXXCompilerFlag)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terminal Quest
 ![travis build status]
-(https://travis-ci.org/jm-janzen/termq.svg?branch=master)
+(https://travis-ci.org/jm-janzen/termq-engine.svg?branch=master)
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/jm-janzen/termq/blob/master/LICENSE.md)
 
 A personal adventure with ncurses.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,47 +1,24 @@
 
-file(GLOB_RECURSE termq_SOURCES "*.cpp")
-file(GLOB_RECURSE termq_HEADERS "*.h")
-#message("TERMQ SOURCES:" ${termq_SOURCES})
-
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 
-# Add all sources except main.cpp
-# TODO include all, then remove main.cpp
+# Assign all source files recursively to `lib_src'
+file(GLOB_RECURSE lib_src *.cpp *.h)
+
+# Except main and cmake
+list(REMOVE_ITEM lib_src main.cpp)
+
+# Print lib_src list for debugging
+message("Adding library source files:")
+foreach(source_file ${lib_src})
+    #message("\t" ${source_file})
+endforeach(source_file)
+
+# Finally add them
 add_library(TERMQ_LIB
-    directions.h
-    game.h
-    gameover.h
-    menu.h
-    entities/Actor.cpp
-    entities/Actor.h
-    entities/Coin.cpp
-    entities/Coin.h
-    entities/Enemy.cpp
-    entities/Enemy.h
-    entities/Entity.cpp
-    entities/Entity.h
-    entities/Item.cpp
-    entities/Item.h
-    entities/Player.cpp
-    entities/Player.h
-    global/difficulty-levels.h
-    global/Global.cpp
-    global/Global.h
-    windows/DiagWindow.cpp
-    windows/DiagWindow.h
-    windows/MenuWindow.cpp
-    windows/MenuWindow.h
-    windows/StatusBar.cpp
-    windows/StatusBar.h
-    windows/Window.cpp
-    windows/Window.h
-    world/Cell.cpp
-    world/Cell.h
-    world/Map.cpp
-    world/Map.h
-    world/World.cpp
-    world/World.h
+    ${lib_src}
 )
 
-add_executable(termq ${termq_SOURCES})
+# Add library target `termq'
+add_library(termq ${lib_src})
 target_link_libraries(termq PRIVATE ${NCURSES_LIBRARIES})
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,6 @@ set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 add_library(TERMQ_LIB
     directions.h
     game.h
-    gameover.cpp
     gameover.h
     menu.h
     entities/Actor.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,5 @@ add_library(TERMQ_LIB
 )
 
 # Add library target `termq'
-add_library(termq ${lib_src})
-target_link_libraries(termq PRIVATE ${NCURSES_LIBRARIES})
-
+add_library(termq_lib ${lib_src})
+target_link_libraries(termq_lib PRIVATE ${NCURSES_LIBRARIES})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,12 +2,14 @@
 include_directories(${TEST_SOURCE_DIR}/src)
 
 add_executable(Test_vec2ui test_vec2ui.cpp)
+set_target_properties(TERMQ_LIB PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(Test_vec2ui
     gtest
     pthread
 )
 
 add_executable(Test_entity test_entity.cpp)
+set_target_properties(TERMQ_LIB PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(Test_entity
     TERMQ_LIB
     gtest
@@ -16,6 +18,7 @@ target_link_libraries(Test_entity
 )
 
 add_executable(Test_item test_item.cpp)
+set_target_properties(TERMQ_LIB PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(Test_item
     TERMQ_LIB
     gtest


### PR DESCRIPTION
Directly related to PR #89 

- [x] Keep tests intact
- [x] Discard main method entry point (leave source for ref (for now))
- [x] Discard game loop (leave source for ref (for now))
- [ ] Decouple classes, configurations, for more arbitrary use.
- [x] Update CMake to build library instead of executable.